### PR TITLE
Update meta url for DLFNova

### DIFF
--- a/Resources/model/stations.js
+++ b/Resources/model/stations.js
@@ -27,7 +27,7 @@ module.exports = {
         id : 1,
         darkcolor : '#006900',
         name : 'Deutschlandfunk Nova',
-        meta : 'https://www.deutschlandfunknova.de/actions/dradio/playlist/onair',
+        meta : 'https://static.deutschlandfunknova.de/actions/dradio/playlist/onair',
         stream : 'http://st03.dlf.de/dlf/03/128/mp3/stream.mp3',
         mediathek : 'http://srv.deutschlandradio.de/aodlistaudio.1706.de.rpc?drau:station_id=1&drau:from=_DATE_&drau:to=_DATE_&drau:page=1&drau:limit=500'
     }


### PR DESCRIPTION
Hey,
I work for codemonauts, we are building and hosting the website of DLFNova and just found your code via the public search on GitHub. We recently changed the URL for the onair API endpoint which is the content of this PR. Currently both are working but maybe we will drop the old one someday so better migrate to the new one :)

Best,
Felix